### PR TITLE
Show deprecation message only when relevant

### DIFF
--- a/addon/helpers/get-glimmer.js
+++ b/addon/helpers/get-glimmer.js
@@ -6,7 +6,9 @@ const { oneWay } = computed;
 
 export default Helper.extend({
   init() {
-    Ember.deprecate('ember-get-helper has been included in Ember 2.0. Use of this package is deprecated.');
+    if (Ember.VERSION.substr(0,1) === '2') {
+      Ember.deprecate('ember-get-helper has been included in Ember 2.0. Use of this package is deprecated.');
+    }
   },
 
   compute(params/*, hash*/) {


### PR DESCRIPTION
I like this helper, unfortunately it's spamming my console to the point where it's unusable.

This will only show the deprecation for people on 2.0, where built in support actually exist (2.0 isn't even released yet, so expecting people to switch now is a bit extreme).

An alternative solution would be to move the deprecation warning into index.js, to only show it once. See e.g. https://github.com/achambers/ember-cli-deploy/blob/82cca5fbd46a/index.js
