### PR TITLE
Fix "Could not find module `ember-get-helpers/helpers/get`" errror

### DIFF
--- a/app/helpers/get.js
+++ b/app/helpers/get.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import { getHelper } from 'ember-get-helpers/helpers/get';
-import getGlimmerHelper from 'ember-get-helpers/helpers/get-glimmer';
+import { getHelper } from 'ember-get-helper/helpers/get';
+import getGlimmerHelper from 'ember-get-helper/helpers/get-glimmer';
 
 var forExport = null;
 


### PR DESCRIPTION
Closes #17.