### PR TITLE
remove an unused dependency

### DIFF
--- a/app/initializers/get-helper.js
+++ b/app/initializers/get-helper.js
@@ -2,7 +2,6 @@ import Em from 'ember';
 import { registerHelper } from 'ember-get-helper/utils/register-helper';
 
 import getHelper from 'ember-get-helper/helpers/get';
-import getHelperGlimmer from 'ember-get-helper/helpers/get-glimmer';
 
 export function initialize(/* container, application */) {
   // Do not register helpers from Ember 1.13 onwards, starting from 1.13 they


### PR DESCRIPTION
`getHelperGlimmer` isn't used anywhere in the module that was importing it, so I removed it.