### PR TITLE
Fix deprecation warnings in ember 2.6 fixes #28

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ module.exports = {
 
   init: function() {
     var checker = new VersionChecker(this);
+
+    this._super.init && this._super.init.apply(this, arguments);
     this._checkerForEmber = checker.for('ember', 'bower');
   },
 


### PR DESCRIPTION
This will remove the deprecation warning produced when using this addon with ember 2.6 (maybe also with other versions).
See issue #28 for more details