### PR TITLE
Address deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
   name: 'ember-get-helper',
 
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
     var checker = new VersionChecker(this);
     this._checkerForEmber = checker.for('ember', 'bower');
   },


### PR DESCRIPTION
This is to fix
>DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-get-helper`